### PR TITLE
単元28 Controllerと入力チェックのテスト

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -59,7 +60,7 @@ public class StudentController {
       responses = {@ApiResponse(responseCode = "200"),
           @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content())})
   @GetMapping("/student/{id}")
-  public StudentDetail getStudent(@PathVariable Integer id) {
+  public StudentDetail getStudent(@PathVariable @Max(99) Integer id) {
     return service.matchID(id);
   }
 

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.groups.Default;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagement.data.StudentValidationGroup.UpdateGroup;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
 
@@ -51,7 +52,7 @@ public class StudentController {
           @ApiResponse(responseCode = "400", description = "バリデーションエラー発生", content = @Content())})
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudent(
-      @RequestBody @Valid StudentDetail studentDetail) {
+      @RequestBody @Validated(Default.class) StudentDetail studentDetail) {
     StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
     return ResponseEntity.ok(responseStudentDetail);
   }
@@ -66,7 +67,8 @@ public class StudentController {
 
   @Operation(summary = "受講生更新", description = "受講生詳細を更新します")
   @PutMapping("/updateResult")
-  public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
+  public ResponseEntity<String> updateStudent(
+      @RequestBody @Validated({Default.class, UpdateGroup.class}) StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
     return ResponseEntity.ok("更新処理が成功しました");
   }

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -59,7 +59,7 @@ public class StudentController {
       responses = {@ApiResponse(responseCode = "200"),
           @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content())})
   @GetMapping("/student/{id}")
-  public StudentDetail updateStudentHyper(@PathVariable Integer id) {
+  public StudentDetail getStudent(@PathVariable Integer id) {
     return service.matchID(id);
   }
 

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -3,14 +3,17 @@ package raisetech.StudentManagement.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import raisetech.StudentManagement.data.StudentValidationGroup.UpdateGroup;
 
 @Schema(description = "受講生情報")
 @Getter
 @Setter
 public class Student {
 
+  @NotNull(groups = UpdateGroup.class, message = "更新時はidが必須です。")
   private Integer id;
 
   @NotBlank

--- a/src/main/java/raisetech/StudentManagement/data/StudentValidationGroup.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentValidationGroup.java
@@ -1,0 +1,9 @@
+package raisetech.StudentManagement.data;
+
+public interface StudentValidationGroup {
+
+  interface UpdateGroup {
+
+  }
+
+}

--- a/src/main/java/raisetech/StudentManagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package raisetech.StudentManagement.exception;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -48,5 +49,10 @@ public class GlobalExceptionHandler {
           cause.getTargetType().getSimpleName());
     }
     return ResponseEntity.badRequest().body(message);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<String> handleConstraintViolation(ConstraintViolationException ex) {
+    return ResponseEntity.badRequest().body("Invalid request: " + ex.getMessage());
   }
 }

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,8 +1,10 @@
 package raisetech.StudentManagement.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -15,11 +17,14 @@ import jakarta.validation.Validator;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
@@ -36,6 +41,12 @@ class StudentControllerTest {
 
   @MockitoBean
   private StudentService service;
+
+  @Captor
+  ArgumentCaptor<StudentDetail> captorStudentDetail;
+
+  @Captor
+  ArgumentCaptor<Integer> captorInteger;
 
   private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
@@ -64,12 +75,88 @@ class StudentControllerTest {
     StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
     String studentDetailJson = objectMapper.writeValueAsString(studentDetail);
 
-    mockMVC.perform(post("/registerStudent"))
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(studentDetailJson)
+    mockMVC.perform(post("/registerStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(studentDetailJson))
         .andExpect(status().isOk());
 
-    verify(service).registerStudent(studentDetail);
+    verify(service).registerStudent(captorStudentDetail.capture());
+    StudentDetail actual = captorStudentDetail.getValue();
+
+    assertThat(actual.getStudent().getName()).isEqualTo("テストN");
+    assertThat(actual.getStudentCourseList().getFirst().getCourse()).isEqualTo("テストC");
+  }
+
+  @Test
+  void 受講生詳細の登録が必要事項に空欄があるとエラーとなること() throws Exception {
+    Student student = new Student();
+    student.setNameKana("テストNK");
+    student.setNickname("テストNN");
+    student.setMail("test@example.com");
+    student.setResion("テストR");
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourse("テストC");
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    String studentDetailJson = objectMapper.writeValueAsString(studentDetail);
+
+    mockMVC.perform(post("/registerStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(studentDetailJson))
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).registerStudent(captorStudentDetail.capture());
+  }
+
+  @Test
+  void 受講生検索が実行できること() throws Exception {
+    Student student = new Student();
+    student.setName("名前");
+    student.setNameKana("なまえ");
+    student.setNickname("名");
+    student.setMail("test@example.com");
+    student.setResion("県");
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourse("テスト");
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+
+    when(service.matchID(1)).thenReturn(studentDetail);
+
+    MvcResult result = mockMVC.perform(get("/student/{id}", 1))
+        .andExpect(status().isOk()).andReturn();
+
+    String jsonResponse = result.getResponse().getContentAsString();
+    StudentDetail actual = objectMapper.readValue(jsonResponse, StudentDetail.class);
+
+    assertThat(actual.getStudent().getName()).isEqualTo("名前");
+    assertThat(actual.getStudentCourseList().getFirst().getCourse()).isEqualTo("テスト");
+    verify(service).matchID(1);
+  }
+
+  @Test
+  void 受講生検索で100以上のidを入力したときにエラーとなること() throws Exception {
+    mockMVC.perform(get("/student/{id}", 100))
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).matchID(any());
+  }
+
+  @Test
+  void 受講生検索で数字以外のidを入力したときにエラーとなること() throws Exception {
+    mockMVC.perform(get("/student/{id}", "あ"))
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).matchID(any());
+  }
+
+  @Test
+  void 受講生更新が実行できること() {
+
   }
 
   @Test
@@ -119,5 +206,14 @@ class StudentControllerTest {
     Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse);
 
     assertThat(violations.size()).isEqualTo(0);
+  }
+
+  @Test
+  void 受講生コース情報でテストが空欄の時入力チェックにかかること() {
+    StudentCourse studentCourse = new StudentCourse();
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse);
+
+    assertThat(violations.size()).isEqualTo(1);
   }
 }

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,0 +1,123 @@
+package raisetech.StudentManagement.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import raisetech.StudentManagement.data.Student;
+import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.service.StudentService;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+  @Autowired
+  private MockMvc mockMVC;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private StudentService service;
+
+  private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void 受講生詳細の一覧検索を実行でき空のリストがかえってくること() throws Exception {
+    mockMVC.perform(get("/studentList"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
+
+    verify(service, times(1)).searchStudentDetailList();
+  }
+
+  @Test
+  void 受講生詳細の登録が正しい形式で入力すると成功すること() throws Exception {
+    Student student = new Student();
+    student.setName("テストN");
+    student.setNameKana("テストNK");
+    student.setNickname("テストNN");
+    student.setMail("test@example.com");
+    student.setResion("テストR");
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourse("テストC");
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    String studentDetailJson = objectMapper.writeValueAsString(studentDetail);
+
+    mockMVC.perform(post("/registerStudent"))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(studentDetailJson)
+        .andExpect(status().isOk());
+
+    verify(service).registerStudent(studentDetail);
+  }
+
+  @Test
+  void 受講生情報で形式通りに入力したときに問題が発生しないこと() {
+    Student student = new Student();
+    student.setName("テスト");
+    student.setNameKana("テスト");
+    student.setNickname("テスト");
+    student.setMail("test@example.com");
+    student.setResion("テスト");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(0);
+  }
+
+  @Test
+  void 受講生情報で必須項目が空欄の時入力チェックにかかること() {
+    Student student = new Student();
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(5);
+  }
+
+  @Test
+  void 受講生情報でメールにアドレスの形式以外を用いたときに入力チャックにかかること() {
+    Student student = new Student();
+    student.setMail("テストです。");
+    student.setName("テスト");
+    student.setNameKana("テスト");
+    student.setNickname("テスト");
+    student.setResion("テスト");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(1);
+    assertThat(violations).extracting("message")
+        .containsOnly("電子メールアドレスとして正しい形式にしてください");
+  }
+
+  @Test
+  void 受講生コース情報で形式通りに入力して問題が発生しないこと() {
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourse("テスト");
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse);
+
+    assertThat(violations.size()).isEqualTo(0);
+  }
+}

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,9 +45,6 @@ class StudentControllerTest {
 
   @Captor
   ArgumentCaptor<StudentDetail> captorStudentDetail;
-
-  @Captor
-  ArgumentCaptor<Integer> captorInteger;
 
   private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
@@ -155,8 +153,48 @@ class StudentControllerTest {
   }
 
   @Test
-  void 受講生更新が実行できること() {
+  void 受講生更新が実行できること() throws Exception {
+    Student student = new Student();
+    student.setId(1);
+    student.setName("テストN");
+    student.setNameKana("テストNK");
+    student.setNickname("テストNN");
+    student.setMail("test@example.com");
+    student.setResion("テストR");
 
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourse("テストC");
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    String studentDetailJson = objectMapper.writeValueAsString(studentDetail);
+
+    mockMVC.perform(put("/updateResult").contentType(MediaType.APPLICATION_JSON)
+        .content(studentDetailJson)).andExpect(status().isOk());
+
+    verify(service).updateStudent(captorStudentDetail.capture());
+  }
+
+  @Test
+  void 受講生更新でidを入力していないときにバリデーションエラーが出ること() throws Exception {
+    Student student = new Student();
+    student.setName("テストN");
+    student.setNameKana("テストNK");
+    student.setNickname("テストNN");
+    student.setMail("test@example.com");
+    student.setResion("テストR");
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourse("テストC");
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    String studentDetailJson = objectMapper.writeValueAsString(studentDetail);
+
+    mockMVC.perform(put("/updateResult").contentType(MediaType.APPLICATION_JSON)
+        .content(studentDetailJson)).andExpect(status().isBadRequest());
+
+    verify(service, times(0)).updateStudent(captorStudentDetail.capture());
   }
 
   @Test

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -1,6 +1,7 @@
 package raisetech.StudentManagement.service;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.times;
@@ -11,7 +12,6 @@ import java.sql.Date;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,7 +80,7 @@ class StudentServiceTest {
 
     verify(repository).searchStudentName("nameTest");
     verify(repository).searchCourseID(1);
-    Assertions.assertEquals(new StudentDetail(student, studentCourse), actual);
+    assertThat(actual).isEqualTo(new StudentDetail(student, studentCourse));
   }
 
   @Test
@@ -92,8 +92,9 @@ class StudentServiceTest {
 
     when(repository.searchStudentName("nameTest")).thenReturn(null);
 
-    TestException ex = assertThrows(TestException.class, () -> sut.matchName(inputStudentDetail));
-    Assertions.assertEquals("存在しない名前です。", ex.getMessage());
+    assertThatThrownBy(() -> sut.matchName(inputStudentDetail))
+        .isInstanceOf(TestException.class)
+        .hasMessageContaining("存在しない名前です。");
     verify(repository, times(0)).searchCourseID(anyInt());
   }
 
@@ -111,15 +112,16 @@ class StudentServiceTest {
 
     verify(repository).searchStudentID(1);
     verify(repository).searchCourseID(1);
-    Assertions.assertEquals(new StudentDetail(student, studentCourse), actual);
+    assertThat(actual).isEqualTo(new StudentDetail(student, studentCourse));
   }
 
   @Test
   void 受講生詳細のID一致での検索機能_入力した受講生IDが存在しないときに例外を投げること() {
     when(repository.searchStudentID(1)).thenReturn(null);
 
-    TestException ex = assertThrows(TestException.class, () -> sut.matchID(1));
-    Assertions.assertEquals("存在しないIDです。", ex.getMessage());
+    assertThatThrownBy(() -> sut.matchID(1))
+        .isInstanceOf(TestException.class)
+        .hasMessageContaining("存在しないIDです。");
     verify(repository, times(0)).searchCourseID(anyInt());
   }
 
@@ -155,8 +157,8 @@ class StudentServiceTest {
     StudentDetail actual = sut.registerStudent(inputStudentDetail);
 
     for (StudentCourse course : actual.getStudentCourseList()) {
-      Assertions.assertEquals(testStartDay, course.getStartDay());
-      Assertions.assertEquals(testEndDay, course.getEndDay());
+      assertThat(course.getStartDay()).isEqualTo(testStartDay);
+      assertThat(course.getEndDay()).isEqualTo(testEndDay);
     }
   }
 


### PR DESCRIPTION
まず、UpdateStudentではidを入力必須とするために、StudentValidationGroupインターフェースを実装し、interface UpdateGroupを作成した。StudentクラスでidにUpdateGroup時のみNotNullとなるようにした。
その後、コントローラー層のregisterStudent、updateStudentの@Validを@Validatedに変更し、UpdateStudentではidを入力必須とした。

コントローラー層のテストはそれぞれが正常に動作することの確認と自身で用意したバリデーションが動作していることを確認した。
Student、StudentCourseクラスの入力チェックは@Notblankと@Emailが動作することを確認した。